### PR TITLE
Add --passWithNoTests option to Jest command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npx jest --ci --coverage
+      - run: npx jest --ci --coverage --passWithNoTests


### PR DESCRIPTION
This pull request makes a minor update to the test workflow configuration. The change allows the Jest test runner to pass even when there are no tests present, which can help avoid unnecessary CI failures during early development or when tests are temporarily absent.