### PR TITLE
Mark paid status updated

### DIFF
--- a/app/checkout/success/page.tsx
+++ b/app/checkout/success/page.tsx
@@ -3,7 +3,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { prisma } from "@/lib/db";
 import { Confetti } from "@/components/confetti";
-import SendReceiptClient from "./send-receipt-client";
 
 export const dynamic = "force-dynamic";
 
@@ -78,8 +77,6 @@ export default async function SuccessPage({
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-brand-cream/20 to-white py-20 px-4">
-      {/* Trigger email send (mark paid) on client-side */}
-      <SendReceiptClient orderId={order.id} />
       <Confetti />
 
       <div className="mx-auto max-w-2xl text-center animate-slide-up">
@@ -168,7 +165,9 @@ export default async function SuccessPage({
             </div>
             {order.discountTotal > 0 && (
               <div className="flex justify-between text-sm text-green-600 font-medium">
-                <span>Discount {order.promoCode ? `(${order.promoCode})` : ""}</span>
+                <span>
+                  Discount {order.promoCode ? `(${order.promoCode})` : ""}
+                </span>
                 <span>
                   -
                   {new Intl.NumberFormat("en-CA", {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,8 +6,6 @@ import { Footer } from "@/components/footer";
 import Providers from "./providers";
 import { Analytics } from "@vercel/analytics/react";
 
-import { SpeedInsights } from "@vercel/speed-insights/next";
-
 export const metadata: Metadata = {
   title: "Sugar Cubed Creations",
   description: "Fresh, chunky, mood-lifting cookies.",
@@ -26,7 +24,6 @@ export default function RootLayout({
           <main className="min-h-screen">{children}</main>
           <Footer />
           <Analytics />
-          <SpeedInsights />
         </Providers>
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@supabase/supabase-js": "^2.58.0",
         "@tabler/icons-react": "^3.35.0",
         "@vercel/analytics": "^1.6.0",
-        "@vercel/speed-insights": "^1.3.0",
         "canvas-confetti": "^1.9.4",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6807,40 +6806,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@vercel/speed-insights": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.3.0.tgz",
-      "integrity": "sha512-ISaZs67WoLfD2xjD2n0iU0GGKW0tRqtk/Ur5RGYE9+ku4vXJ+k9GWJL8rRqCpwJ8SVgMvhTPDflSHGgP9wlnAw==",
-      "peerDependencies": {
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitejs/plugin-vue": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@supabase/supabase-js": "^2.58.0",
     "@tabler/icons-react": "^3.35.0",
     "@vercel/analytics": "^1.6.0",
-    "@vercel/speed-insights": "^1.3.0",
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
This pull request primarily removes the Vercel Speed Insights integration from the codebase and cleans up the checkout success page. The most significant changes are the removal of the `@vercel/speed-insights` package and its usage, as well as a minor UI adjustment on the order success page.

**Removal of Vercel Speed Insights:**

* Deleted the import and usage of `SpeedInsights` from `app/layout.tsx`, removing the performance monitoring component from the application. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL9-L10) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL29)
* Removed `@vercel/speed-insights` from the dependencies in `package.json`, ensuring the package is no longer installed.

**Checkout Success Page Cleanup:**

* Removed the `SendReceiptClient` component from `app/checkout/success/page.tsx`, which previously triggered email sending on the client-side. [[1]](diffhunk://#diff-19acf438bcfd945f62690e6ff4f9afe673e61d85449ef22782df6de114df5601L6) [[2]](diffhunk://#diff-19acf438bcfd945f62690e6ff4f9afe673e61d85449ef22782df6de114df5601L81-L82)
* Minor formatting improvement to the discount display logic in the order summary, making the code more readable.